### PR TITLE
utils: remove `toolkit.ts` and `es-toolkit` re-exports, and enhance `…

### DIFF
--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -26,16 +26,8 @@ npm install @esmate/utils
 Access [es-toolkit](https://es-toolkit.dev/reference/array/at.html) functions through the main package export or the
 dedicated toolkit subpath.
 
-**Import from main package:**
-
 ```ts
 import { delay, invariant } from "@esmate/utils";
-```
-
-**Import from toolkit subpath:**
-
-```ts
-import { delay, invariant } from "@esmate/utils/toolkit";
 ```
 
 📚 **Documentation**: [es-toolkit reference](https://es-toolkit.dev/reference/array/at.html)
@@ -76,7 +68,11 @@ Converts strings to proper title case using the [title](https://www.npmjs.com/pa
 ```ts
 import { titleize } from "@esmate/utils/string";
 
-const result = titleize("hello world"); // "Hello World"
+const title = titleize("hello world"); // "Hello World"
+
+const chicagoTitle = titleize("love of my life", { style: "chicago" }); // "Love of My Life"
+
+const specialTitle = titleize("i love ESMate", { special: ["ESMate"] }); // "I Love ESMate"
 ```
 
 📚 **Documentation**: [View source](https://github.com/VienDinhCom/esmate/blob/main/packages/utils/src/string.ts)

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@esmate/utils",
   "type": "module",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "JavaScript/TypeScript utils, functions, and classes in one package.",
   "license": "MIT",
   "repository": {
@@ -19,8 +19,8 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/toolkit.d.ts",
-      "import": "./dist/toolkit.js"
+      "types": "./dist/pkgs/es-toolkit.d.ts",
+      "import": "./dist/pkgs/es-toolkit.js"
     },
     "./*": {
       "types": "./dist/*.d.ts",

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -10,10 +10,10 @@ import typopo from "typopo";
  * @param options The options to use.
  * @returns The formatted string.
  */
-export function titleize(str: string, options?: { locale?: "en"; special?: string[] }): string {
+export function titleize(str: string, options?: { style?: "chicago"; special?: string[] }): string {
   str = str.replace(/\s+/g, " ");
 
-  if (options?.locale === "en") {
+  if (options?.style === "chicago") {
     return title(str, options);
   }
 

--- a/packages/utils/src/toolkit.ts
+++ b/packages/utils/src/toolkit.ts
@@ -1,1 +1,0 @@
-export * from "es-toolkit";


### PR DESCRIPTION
…titleize` function with a new `style` option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated usage examples for string utilities

* **Updates**
  * Titleize function API updated: replaced locale option with style option, introducing "chicago" style support
  * Version bumped to 1.3.0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->